### PR TITLE
Fix personas link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository holds a collection of [learner personas][personas] developed for training by certified RStudio instructors.
 
-[personas]: http://teachtogether.tech/#s:process-personas
+[personas]: http://teachtogether.tech/en/#s:process-personas


### PR DESCRIPTION
Current link redirects to language choice screen. Proposed change points to English language version, given the language of the surrounding sentence.